### PR TITLE
fix/openaichat citations, images, videos, forecast

### DIFF
--- a/g4f/providers/response.py
+++ b/g4f/providers/response.py
@@ -64,7 +64,7 @@ def format_link(url: str, title: Optional[str] = None) -> str:
     Returns:
         str: The formatted markdown link
     """
-    if title is None:
+    if title is None or not title.strip():
         try:
             title = unquote(url.split("//", maxsplit=1)[1].split("?")[0].replace("www.", ""))
         except IndexError:


### PR DESCRIPTION
When images, videos, products, or forecast data are embedded, the response contains special sequences like `i\nturn0image0\nturn0image1\nturn0image3\nturn0image5`. Also, the indexes in URL references don't match because the number that comes after `turn0news` and `turn0search` is treated as an index in the sources list.

I have implemented URL reference matching using `ref_index` and `ref_type` fields in sources that correspond to the ref type and ref index from these special sequences.

Also, from time to time, one event/operation can contain multiple special sequences: `Good thermals < 60 °C, ~247–273 W peak citeturn0search9turn0search9 | ~2850 MHz avg (2.8–2.9 GHz turbo) cite`. This string has two sequences — one that is completed and a second that is just starting. The old implementation strips all `\ue200` and `\ue202` characters in current buffer and breaks sequences that are not completed yet.

I have also added a `ContentReferences` class that tries to maintain content references using corresponding events from the stream. It is not a completed solution, but it handles most cases for product, image, video, and forecast references.

<img width="1540" alt="image" src="https://github.com/user-attachments/assets/1b8d22b9-be1a-45d9-8d6b-b394ca6783ff" />